### PR TITLE
provide default callback in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash')
 
 var defaultOptions = require('./lib/cli/default-options')
+var exitOnFailure = require('./lib/cli/exit-on-failure')
 var buildTestHelper = require('./lib/build-test-helper')
 var criteriaFor = require('./lib/criteria-for')
 var buildTestModules = require('./lib/build-test-modules')
@@ -13,7 +14,7 @@ var pluginsStore = require('./lib/plugins/store')
 
 module.exports = function (testLocator, userOptions, cb) {
   // 1. options setup
-  if (arguments.length < 3) { cb = userOptions; userOptions = {} }
+  if (arguments.length < 3) { cb = userOptions || exitOnFailure; userOptions = {} }
   var cwd = userOptions.cwd || process.cwd()
   var helper = buildTestHelper(userOptions.helperPath, cwd)
   var options = _.defaults({}, helper.options, userOptions, defaultOptions())

--- a/lib/cli/exit-on-failure.js
+++ b/lib/cli/exit-on-failure.js
@@ -1,0 +1,3 @@
+module.exports = function (error, passing) {
+  process.exit(!error && passing ? 0 : 1)
+}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,12 +3,11 @@ var _ = require('lodash')
 var teenytest = require('../../index')
 var argvOptions = require('./argv-options')
 var parsePackageOptions = require('./parse-package-options')
+var exitOnFailure = require('./exit-on-failure')
 
 module.exports = function () {
   parsePackageOptions(function (er, packageOpts) {
     var options = _.defaults(argvOptions(), packageOpts)
-    teenytest(options.testLocator, options, function (er, passing) {
-      process.exit(!er && passing ? 0 : 1)
-    })
+    teenytest(options.testLocator, options, exitOnFailure)
   })
 }


### PR DESCRIPTION
Extract cli's callback into `lib/cli/exit-on-failure` and use as default callback. This lets you call teenytest via the api with even less configuration.

Where the readme suggests:

```js
  teenytest('test/lib/**/*.js', {
    helperPath: 'test/helper.js', // module that exports test hook functions (default: null)
    output: console.log, // output for writing results
    cwd: process.cwd(), // base path for test globs & helper path,
    asyncTimeout: 5000 // milliseconds to wait before triggering failure of async tests & hooks
  }, function(er, passing) {
    process.exit(!er && passing ? 0 : 1)
  })
```

you could use defaults by invoking as

```js
  teenytest('test/lib/**/*.js', function(er, passing) {
    process.exit(!er && passing ? 0 : 1)
  })
```

but now you can just invoke as

```js
  teenytest('test/lib/**/*.js')
```

This may seem inconsiquential, but among other things it allows a one-liner to be added to test modules which lets them self invoke with `node my-test.js`, as well as conventionally with `teenytest my-test.js`

For example, a module (`foo.js`) containing the following:

```js
module.exports = function() {
  console.log('i will run as a test!')
}

module.parent || require('teenytest')(module.filename)
```

will still run with `teenytest foo.js` as well as standalone with `node foo`