### PR TITLE
require individual lodash functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _defaults = require('lodash/defaults')
 
 var defaultOptions = require('./lib/cli/default-options')
 var buildTestHelper = require('./lib/build-test-helper')
@@ -15,7 +15,7 @@ module.exports = function (testLocator, userOptions, cb) {
   // 1. options setup
   if (arguments.length < 3) { cb = userOptions; userOptions = {} }
   var cwd = userOptions.cwd || process.cwd()
-  var options = _.defaults({}, userOptions, defaultOptions())
+  var options = _defaults({}, userOptions, defaultOptions())
   var helper = buildTestHelper(options.helperPath, cwd)
 
   var log = options.output

--- a/lib/build-test-actions.js
+++ b/lib/build-test-actions.js
@@ -1,4 +1,9 @@
 var _ = require('lodash')
+var _drop = require('lodash/drop')
+var _flatten = require('lodash/flatten')
+var _hasIn = require('lodash/hasIn')
+var _isNil = require('lodash/isNil')
+var _map = require('lodash/map')
 var async = require('async')
 
 var id
@@ -11,15 +16,15 @@ module.exports = function (glob, testModules, helper) {
     type: 'suite',
     file: glob,
     ancestorNames: [],
-    children: _.flatten([
+    children: _flatten([
       actionForHook(helper.beforeAll, 'global', 'beforeAll', null, helper.file),
-      _.map(testModules, function (exampleGroup) {
+      _map(testModules, function (exampleGroup) {
         return actionsForExampleGroup(exampleGroup, [], helper, stats)
       }),
       actionForHook(helper.afterAll, 'global', 'afterAll', null, helper.file)
     ]),
     callable: function (cb) {
-      async.series(_.map(suite.children, 'callable'), cb)
+      async.series(_map(suite.children, 'callable'), cb)
     }
   }
 
@@ -28,16 +33,16 @@ module.exports = function (glob, testModules, helper) {
 
 var actionsForExampleGroup = function (exampleGroup, ancestors, helper, stats) {
   var name = exampleGroup.name
-  var hookName = _.drop(exampleGroup.ancestorNames, 2).join(' ') || 'module'
+  var hookName = _drop(exampleGroup.ancestorNames, 2).join(' ') || 'module'
   var suite = {
     id: ++id,
     name: name,
     type: 'suite',
     file: exampleGroup.file,
     ancestorNames: exampleGroup.ancestorNames,
-    children: _.flatten([
+    children: _flatten([
       actionForHook(exampleGroup.beforeAll, hookName, 'beforeAll', null, exampleGroup.file),
-      _.map(exampleGroup.items, function (item) {
+      _map(exampleGroup.items, function (item) {
         if (item.type === 'suite') {
           return actionsForExampleGroup(item, ancestors.concat(exampleGroup), helper, stats)
         } else {
@@ -47,7 +52,7 @@ var actionsForExampleGroup = function (exampleGroup, ancestors, helper, stats) {
       actionForHook(exampleGroup.afterAll, hookName, 'afterAll', null, exampleGroup.file)
     ]),
     callable: function (cb) {
-      async.series(_.map(suite.children, 'callable'), cb)
+      async.series(_map(suite.children, 'callable'), cb)
     }
   }
 
@@ -63,13 +68,13 @@ var actionsForTestFunctions = function (test, ancestors, helper, stats) {
     description: test.description(stats.suiteCount, stats.fileCounts[test.file]),
     ancestorNames: test.ancestorNames,
     isAssociatedWithATest: true,
-    children: _.flatten([
+    children: _flatten([
       beforeEachActions(helper, test, ancestors),
       actionForTest(test, stats),
       afterEachActions(helper, test, ancestors)
     ]),
     callable: function (cb) {
-      async.series(_.map(testActions.children, 'callable'), cb)
+      async.series(_map(testActions.children, 'callable'), cb)
     }
   }
 
@@ -80,7 +85,7 @@ function beforeEachActions (helper, test, ancestors) {
   var maxDistance = ancestors.length
   var globalBeforeEach = actionForHook(helper.beforeEach, 'global', 'beforeEach',
                                        test.context, helper.file, maxDistance)
-  return [globalBeforeEach].concat(_.map(ancestors, function (ancestor, i) {
+  return [globalBeforeEach].concat(_map(ancestors, function (ancestor, i) {
     return actionForAncestorHook('beforeEach', ancestor, maxDistance - 1 - i, test)
   }))
 }
@@ -95,7 +100,7 @@ function afterEachActions (helper, test, ancestors) {
 }
 
 function actionForAncestorHook (type, ancestor, distanceFromTest, test) {
-  var name = _.drop(test.ancestorNames, 2).join(' ') || 'module'
+  var name = _drop(test.ancestorNames, 2).join(' ') || 'module'
   return actionForHook(ancestor[type], name,
                        type, test.context, ancestor.file, distanceFromTest)
 }
@@ -110,7 +115,7 @@ var actionForHook = function (helperFunc, name, hookType, context, file, distanc
     description: 'test hook: "' + name + ' ' + hookType + '"' +
                  (file ? ' defined in `' + file + '`' : ''),
     callable: helperFunc.bind(context || {}),
-    isAssociatedWithATest: !_.isNil(context),
+    isAssociatedWithATest: !_isNil(context),
     distanceFromTest: distance || 0
   }
 
@@ -134,7 +139,7 @@ var actionForTest = function (test, stats) {
 
 function incrementCounts (stats, test) {
   stats.suiteCount++
-  if (_.hasIn(stats.fileCounts, test.file)) {
+  if (_hasIn(stats.fileCounts, test.file)) {
     stats.fileCounts[test.file]++
   } else {
     stats.fileCounts[test.file] = 1

--- a/lib/build-test-actions.js
+++ b/lib/build-test-actions.js
@@ -1,4 +1,3 @@
-var _ = require('lodash')
 var _drop = require('lodash/drop')
 var _flatten = require('lodash/flatten')
 var _hasIn = require('lodash/hasIn')
@@ -94,9 +93,9 @@ function afterEachActions (helper, test, ancestors) {
   var maxDistance = ancestors.length
   var globalAfterEach = actionForHook(helper.afterEach, 'global', 'afterEach',
                                       test.context, helper.file, maxDistance)
-  return _(ancestors).reverse().map(function (ancestor, i) {
+  return ancestors.reverse().map(function (ancestor, i) {
     return actionForAncestorHook('afterEach', ancestor, i, test)
-  }).value().concat(globalAfterEach)
+  }).concat(globalAfterEach)
 }
 
 function actionForAncestorHook (type, ancestor, distanceFromTest, test) {

--- a/lib/build-test-helper.js
+++ b/lib/build-test-helper.js
@@ -1,11 +1,12 @@
-var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _defaults = require('lodash/defaults')
 var fs = require('fs')
 var path = require('path')
 
 function noOpHook () {}
 
 module.exports = function (helperPath, cwd) {
-  return _.defaults(buildUserHelper(helperPath, cwd), {
+  return _defaults(buildUserHelper(helperPath, cwd), {
     beforeAll: noOpHook,
     afterAll: noOpHook,
     beforeEach: noOpHook,
@@ -16,7 +17,7 @@ module.exports = function (helperPath, cwd) {
 
 function buildUserHelper (helperPath, cwd) {
   if (helperPath && fs.existsSync(helperPath)) {
-    return _.assign({}, require(path.resolve(cwd, helperPath)), {
+    return _assign({}, require(path.resolve(cwd, helperPath)), {
       file: helperPath
     })
   }

--- a/lib/build-test-modules.js
+++ b/lib/build-test-modules.js
@@ -1,8 +1,8 @@
 var glob = require('glob')
 var path = require('path')
-var _ = require('lodash')
 var _assign = require('lodash/assign')
 var _drop = require('lodash/drop')
+var _identity = require('lodash/identity')
 var _includes = require('lodash/includes')
 var _isFunction = require('lodash/isFunction')
 var _isPlainObject = require('lodash/isPlainObject')
@@ -42,7 +42,7 @@ var itemsIn = function (groupDeclaration, file, ancestors) {
   if (_isFunction(groupDeclaration)) {
     return [buildTest(groupDeclaration.name, groupDeclaration, file, ancestors)]
   } else {
-    return _(groupDeclaration).map(function (item, name) {
+    return _map(groupDeclaration, function (item, name) {
       if (_includes(HOOK_NAMES, name)) {
         return undefined
       } else if (_isFunction(item)) {
@@ -50,7 +50,7 @@ var itemsIn = function (groupDeclaration, file, ancestors) {
       } else if (_isPlainObject(item)) {
         return buildExampleGroup(name, item, file, ancestors)
       }
-    }).compact().value()
+    }).filter(_identity)
   }
 }
 

--- a/lib/build-test-modules.js
+++ b/lib/build-test-modules.js
@@ -1,12 +1,19 @@
 var glob = require('glob')
 var path = require('path')
 var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _drop = require('lodash/drop')
+var _includes = require('lodash/includes')
+var _isFunction = require('lodash/isFunction')
+var _isPlainObject = require('lodash/isPlainObject')
+var _map = require('lodash/map')
+var _tap = require('lodash/tap')
 
 function noOpHook () {}
 var HOOK_NAMES = ['beforeEach', 'beforeAll', 'afterEach', 'afterAll']
 
 module.exports = function (globPattern, cwd) {
-  return _.map(glob.sync(globPattern), function (file) {
+  return _map(glob.sync(globPattern), function (file) {
     var testPath = path.resolve(cwd, file)
     var testModule = require(testPath)
 
@@ -15,7 +22,7 @@ module.exports = function (globPattern, cwd) {
 }
 
 function buildExampleGroup (name, groupDeclaration, file, ancestors) {
-  return _.tap({
+  return _tap({
     name: name,
     type: 'suite',
     file: file,
@@ -23,24 +30,24 @@ function buildExampleGroup (name, groupDeclaration, file, ancestors) {
     afterAll: groupDeclaration.afterAll || noOpHook,
     beforeEach: groupDeclaration.beforeEach || noOpHook,
     afterEach: groupDeclaration.afterEach || noOpHook,
-    ancestorNames: _.map(ancestors, 'name')
+    ancestorNames: _map(ancestors, 'name')
   }, function (exampleGroup) {
-    _.assign(exampleGroup, {
+    _assign(exampleGroup, {
       items: itemsIn(groupDeclaration, file, ancestors.concat(exampleGroup))
     })
   })
 }
 
 var itemsIn = function (groupDeclaration, file, ancestors) {
-  if (_.isFunction(groupDeclaration)) {
+  if (_isFunction(groupDeclaration)) {
     return [buildTest(groupDeclaration.name, groupDeclaration, file, ancestors)]
   } else {
     return _(groupDeclaration).map(function (item, name) {
-      if (_.includes(HOOK_NAMES, name)) {
+      if (_includes(HOOK_NAMES, name)) {
         return undefined
-      } else if (_.isFunction(item)) {
+      } else if (_isFunction(item)) {
         return buildTest(name, item, file, ancestors)
-      } else if (_.isPlainObject(item)) {
+      } else if (_isPlainObject(item)) {
         return buildExampleGroup(name, item, file, ancestors)
       }
     }).compact().value()
@@ -48,15 +55,15 @@ var itemsIn = function (groupDeclaration, file, ancestors) {
 }
 
 function buildTest (name, testFunction, file, ancestors) {
-  return _.tap({
+  return _tap({
     name: name,
     type: 'test',
     testFunction: testFunction,
     context: Object.create(null),
     file: file,
-    ancestorNames: _.map(ancestors, 'name')
+    ancestorNames: _map(ancestors, 'name')
   }, function (test) {
-    _.assign(test, {
+    _assign(test, {
       description: function (suiteOrdinal, fileOrdinal) {
         return testDescription(test, suiteOrdinal, fileOrdinal)
       }
@@ -65,7 +72,7 @@ function buildTest (name, testFunction, file, ancestors) {
 }
 
 function testDescription (test, suiteOrdinal, fileOrdinal) {
-  var fullName = _.drop(test.ancestorNames, 2).concat(test.name).join(' ')
+  var fullName = _drop(test.ancestorNames, 2).concat(test.name).join(' ')
   return suiteOrdinal + ' - ' +
          (fullName ? '"' + fullName + '" - ' : '') +
          'test #' + fileOrdinal +

--- a/lib/cli/argv-options.js
+++ b/lib/cli/argv-options.js
@@ -1,14 +1,16 @@
-var _ = require('lodash')
+var _castArray = require('lodash/castArray')
+var _last = require('lodash/last')
+
 var minimist = require('minimist')
 
 module.exports = function () {
   var argv = minimist(process.argv.slice(2))
 
   return {
-    testLocator: _.last(argv['_']),
+    testLocator: _last(argv['_']),
     helperPath: argv['helper'],
     asyncTimeout: argv['timeout'],
     configurator: argv['configurator'],
-    plugins: argv['plugin'] ? _.castArray(argv['plugin']) : undefined
+    plugins: argv['plugin'] ? _castArray(argv['plugin']) : undefined
   }
 }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _defaults = require('lodash/defaults')
 
 var teenytest = require('../../index')
 var argvOptions = require('./argv-options')
@@ -6,7 +6,7 @@ var parsePackageOptions = require('./parse-package-options')
 
 module.exports = function () {
   parsePackageOptions(function (er, packageOpts) {
-    var options = _.defaults(argvOptions(), packageOpts)
+    var options = _defaults(argvOptions(), packageOpts)
     teenytest(options.testLocator, options, function (er, passing) {
       process.exit(!er && passing ? 0 : 1)
     })

--- a/lib/criteria-for.js
+++ b/lib/criteria-for.js
@@ -1,14 +1,14 @@
-var _ = require('lodash')
+var _includes = require('lodash/includes')
 
 module.exports = function criteriaFor (locator) {
   var parts
-  if (_.includes(locator, '#')) {
+  if (_includes(locator, '#')) {
     parts = locator.split('#')
     return {
       glob: parts[0],
       name: parts[1]
     }
-  } else if (_.includes(locator, ':')) {
+  } else if (_includes(locator, ':')) {
     parts = locator.split(':')
     return {
       glob: parts[0],

--- a/lib/cull-testless-groups.js
+++ b/lib/cull-testless-groups.js
@@ -1,4 +1,6 @@
-var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _reject = require('lodash/reject')
+
 var filterDeep = require('lodash-deeper').filterDeep
 
 module.exports = function (testModules) {
@@ -6,8 +8,8 @@ module.exports = function (testModules) {
 }
 
 function cull (exampleGroup) {
-  return _.assign(exampleGroup, {
-    items: _.reject(exampleGroup.items, function (item) {
+  return _assign(exampleGroup, {
+    items: _reject(exampleGroup.items, function (item) {
       return item.type === 'suite' &&
         filterDeep(cull(item), ['type', 'test']).length === 0
     })

--- a/lib/filter-selected-tests.js
+++ b/lib/filter-selected-tests.js
@@ -1,10 +1,15 @@
-var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _includes = require('lodash/includes')
+var _map = require('lodash/map')
+var _some = require('lodash/some')
+var _transform = require('lodash/transform')
+
 var functionNamesAtLine = require('function-names-at-line')
 var fs = require('fs')
 var path = require('path')
 
 module.exports = function (testModules, criteria, cwd) {
-  return _.map(testModules, function (testModule) {
+  return _map(testModules, function (testModule) {
     if (criteria.name) {
       return filterTestFunctionsByNames(testModule, [criteria.name])
     } else if (criteria.lineNumber && hasNamedTestFunctions(testModule)) {
@@ -18,8 +23,8 @@ module.exports = function (testModules, criteria, cwd) {
 }
 
 function filterTestFunctionsByNames (exampleGroup, names) {
-  return _.assign({}, exampleGroup, {
-    items: _.transform(exampleGroup.items, function (memo, item) {
+  return _assign({}, exampleGroup, {
+    items: _transform(exampleGroup.items, function (memo, item) {
       if (itemPlusAncestorsMatchesAnyNames(item, names)) {
         memo.push(item)
       } else if (item.type === 'suite') {
@@ -31,11 +36,11 @@ function filterTestFunctionsByNames (exampleGroup, names) {
 }
 
 function itemPlusAncestorsMatchesAnyNames (item, names) {
-  return _.some(names, function (n) {
-    return _.includes(item.ancestorNames.concat(item.name).join(' '), n)
+  return _some(names, function (n) {
+    return _includes(item.ancestorNames.concat(item.name).join(' '), n)
   })
 }
 
 function hasNamedTestFunctions (testModule) {
-  return _.some(testModule.items, 'name')
+  return _some(testModule.items, 'name')
 }

--- a/lib/plugins/store.js
+++ b/lib/plugins/store.js
@@ -1,5 +1,5 @@
-var _ = require('lodash')
 var _compact = require('lodash/compact')
+var _filter = require('lodash/filter')
 var _find = require('lodash/find')
 var _map = require('lodash/map')
 
@@ -49,7 +49,7 @@ module.exports = {
 }
 
 function wrappersFor (lifecycleEvent, scope) {
-  return _(store.all('plugins')).filter(lifecycleEvent + '.' + scope)
+  return _filter(store.all('plugins'), lifecycleEvent + '.' + scope)
     .map(function (plugin) {
       return {
         name: plugin.name,
@@ -57,7 +57,7 @@ function wrappersFor (lifecycleEvent, scope) {
         lifecycleEvent: lifecycleEvent,
         wrap: plugin[lifecycleEvent][scope]
       }
-    }).value()
+    })
 }
 
 function ensureStoreIsInitialized () {

--- a/lib/plugins/store.js
+++ b/lib/plugins/store.js
@@ -1,4 +1,7 @@
 var _ = require('lodash')
+var _compact = require('lodash/compact')
+var _find = require('lodash/find')
+var _map = require('lodash/map')
 
 var store = require('../store')
 
@@ -8,10 +11,10 @@ store.onInitialize(function () {
 
 module.exports = {
   list: function () {
-    return _.map(store.all('plugins'), 'name')
+    return _map(store.all('plugins'), 'name')
   },
   wrappers: function (scope) {
-    return _.compact([].concat(wrappersFor('translators', scope))
+    return _compact([].concat(wrappersFor('translators', scope))
                        .concat(wrappersFor('supervisors', scope))
                        .concat(wrappersFor('analyzers', scope))
                        .concat(wrappersFor('interceptors', scope))
@@ -23,7 +26,7 @@ module.exports = {
       throw new Error('Plugins are required to have a "name" attribute.')
     }
 
-    var existing = _.find(store.all('plugins'), ['name', definition.name])
+    var existing = _find(store.all('plugins'), ['name', definition.name])
     if (existing) {
       if (existing === definition) {
         store.destroy('plugins', existing.name)

--- a/lib/plugins/wrap.js
+++ b/lib/plugins/wrap.js
@@ -1,4 +1,7 @@
-var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _omit = require('lodash/omit')
+var _reduce = require('lodash/reduce')
+
 var pluginsStore = require('./store')
 var resultsStore = require('../report/results-store')
 var userFunctionStore = require('./user-function-store')
@@ -13,10 +16,10 @@ module.exports = function wrap (action) {
 }
 
 function wrapUserFunction (action) {
-  var metadata = _.omit(action, 'callable')
+  var metadata = _omit(action, 'callable')
   action.callable = callbackify(metadata, action.callable)
 
-  return _.reduce(pluginsStore.wrappers(action.type), function (memo, wrapper) {
+  return _reduce(pluginsStore.wrappers(action.type), function (memo, wrapper) {
     var callable = memo.callable
     var runX = function (cb) {
       callable(function (er, value) {
@@ -24,7 +27,7 @@ function wrapUserFunction (action) {
       })
     }
 
-    return _.assign(memo, {
+    return _assign(memo, {
       callable: function (cb) {
         return wrapper.wrap(runX, metadata, function (er, value) {
           userFunctionStore.setPlugin(metadata, value, er, wrapper.name)
@@ -36,9 +39,9 @@ function wrapUserFunction (action) {
 }
 
 function wrapTestOrSuite (action) {
-  var metadata = _.omit(action, 'callable')
+  var metadata = _omit(action, 'callable')
 
-  return _.reduce(pluginsStore.wrappers(action.type), function (memo, wrapper) {
+  return _reduce(pluginsStore.wrappers(action.type), function (memo, wrapper) {
     var callable = memo.callable
     var runX = function (cb) {
       callable(function (er) {
@@ -46,7 +49,7 @@ function wrapTestOrSuite (action) {
       })
     }
 
-    return _.assign(memo, {
+    return _assign(memo, {
       callable: function (cb) {
         return wrapper.wrap(runX, metadata, cb)
       }

--- a/lib/report/results-store.js
+++ b/lib/report/results-store.js
@@ -1,8 +1,8 @@
-var _ = require('lodash')
 var _assign = require('lodash/assign')
 var _each = require('lodash/each')
 var _get = require('lodash/get')
 var _last = require('lodash/last')
+var _map = require('lodash/map')
 var _omit = require('lodash/omit')
 var _set = require('lodash/set')
 var _some = require('lodash/some')
@@ -82,7 +82,7 @@ module.exports = resultsStore = {
   // In the above example, if test 'foo bar baz' fails, it'll be at a distance
   // less than the final afterEach, so that afterEach ought to be run.
   afterEachCleanupNecessary: function (afterEachDistanceFromTest) {
-    return _(current().errors).map('metadata').some(function (errorMetadata) {
+    return _map(current().errors, 'metadata').some(function (errorMetadata) {
       return errorMetadata.isAssociatedWithATest &&
              errorMetadata.distanceFromTest <= afterEachDistanceFromTest
     })

--- a/lib/report/results-store.js
+++ b/lib/report/results-store.js
@@ -1,4 +1,11 @@
 var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _each = require('lodash/each')
+var _get = require('lodash/get')
+var _last = require('lodash/last')
+var _omit = require('lodash/omit')
+var _set = require('lodash/set')
+var _some = require('lodash/some')
 
 var store = require('../store')
 
@@ -15,14 +22,14 @@ module.exports = resultsStore = {
     return get(metadata)
   },
   isPassing: function () {
-    return !_.some(store.all('results'), ['passing', false])
+    return !_some(store.all('results'), ['passing', false])
   },
   currentTestHasFailed: function () {
-    return _.get(current(), 'passing') === false
+    return _get(current(), 'passing') === false
   },
   // Return true if a beforeAll failed and the suite should not be run
   currentTestSetUpFailed: function () {
-    return _.some(currentNesting, 'setUpFailed')
+    return _some(currentNesting, 'setUpFailed')
   },
 
   // Mutate current context
@@ -48,8 +55,8 @@ module.exports = resultsStore = {
       result.setUpFailed = true
     }
 
-    _.each(currentNesting, function (nestedResult) {
-      _.set(nestedResult, 'passing', false)
+    _each(currentNesting, function (nestedResult) {
+      _set(nestedResult, 'passing', false)
     })
   },
   failTest: function (metadata) {
@@ -87,7 +94,7 @@ function get (metadata) {
 }
 
 function createResult (metadata) {
-  var result = set(metadata, _.assign(_.omit(metadata, 'callable'), {
+  var result = set(metadata, _assign(_omit(metadata, 'callable'), {
     passing: true,
     setUpFailed: false,
     errors: [],
@@ -112,7 +119,7 @@ function set (metadata, result) {
 }
 
 function current () {
-  return _.last(currentNesting)
+  return _last(currentNesting)
 }
 
 function clearNestedFailures (result) {
@@ -120,7 +127,7 @@ function clearNestedFailures (result) {
   result.setUpFailed = false
   result.errors = []
 
-  _.each(result.children, function (child) {
+  _each(result.children, function (child) {
     clearNestedFailures(child)
   })
 }

--- a/lib/report/tap13.js
+++ b/lib/report/tap13.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _isNil = require('lodash/isNil')
 
 function Tap13 (log) {
   this.log = log
@@ -18,7 +18,7 @@ Tap13.prototype.test = function (description, info) {
 }
 
 Tap13.prototype.error = function (er, standaloneDescription) {
-  if (!_.isNil(standaloneDescription)) {
+  if (!_isNil(standaloneDescription)) {
     this.log(' An error occurred in ' + standaloneDescription)
   }
   this.log('  ---')

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _each = require('lodash/each')
 var wrap = require('../plugins/wrap')
 
 var store = require('../store')
@@ -29,7 +29,7 @@ module.exports = function (rootAction, options, cb) {
 var wrapCallablesInTree = function (node) {
   node.callable = wrap(node).callable
   if (node.children) {
-    _.each(node.children, wrapCallablesInTree)
+    _each(node.children, wrapCallablesInTree)
   }
 }
 

--- a/lib/runner/register-user-plugins.js
+++ b/lib/runner/register-user-plugins.js
@@ -1,6 +1,6 @@
+var _isFunction = require('lodash/isFunction')
 var async = require('async')
 var doubleResolve = require('./double-resolve')
-var _ = require('lodash')
 
 var pluginsStore = require('../plugins/store')
 
@@ -9,7 +9,7 @@ module.exports = function (cwd, pluginPaths, cb) {
     doubleResolve(pluginPath, {basedir: cwd}, function (er, fullPluginPath) {
       if (er) return cb(er)
       var plugin = require(fullPluginPath)
-      pluginsStore.register(_.isFunction(plugin) ? plugin() : plugin)
+      pluginsStore.register(_isFunction(plugin) ? plugin() : plugin)
       cb(null)
     })
   }, cb)

--- a/lib/runner/run-custom-configurator.js
+++ b/lib/runner/run-custom-configurator.js
@@ -1,4 +1,4 @@
-var _ = require('lodash')
+var _isFunction = require('lodash/isFunction')
 
 var doubleResolve = require('./double-resolve')
 
@@ -6,7 +6,7 @@ module.exports = function (cwd, configurator, cb) {
   if (!configurator) return cb(null)
   var teenytest = require('../../index')
 
-  if (_.isFunction(configurator)) {
+  if (_isFunction(configurator)) {
     configurator(teenytest, cb)
   } else {
     doubleResolve(configurator, {basedir: cwd}, function (er, fullPath) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,4 +1,7 @@
-var _ = require('lodash')
+var _assign = require('lodash/assign')
+var _each = require('lodash/each')
+var _has = require('lodash/has')
+var _isNil = require('lodash/isNil')
 
 var store
 var subscribers = []
@@ -6,7 +9,7 @@ var subscribers = []
 module.exports = {
   initialize: function () {
     store = {}
-    _.each(subscribers, function (subscriber) {
+    _each(subscribers, function (subscriber) {
       subscriber()
     })
   },
@@ -29,7 +32,7 @@ module.exports = {
   },
   update: function (storeName, id, attrs) {
     store[storeName][id] = store[storeName][id] || {}
-    _.assign(store[storeName][id], attrs)
+    _assign(store[storeName][id], attrs)
   },
   destroy: function (storeName, id) {
     delete store[storeName][id]
@@ -37,10 +40,10 @@ module.exports = {
 
   // Other queries
   isInitialized: function () {
-    return !_.isNil(store)
+    return !_isNil(store)
   },
   ensure: function (storeName, id) {
-    if (!_.has(store, storeName + '.' + id)) {
+    if (!_has(store, storeName + '.' + id)) {
       store[storeName][id] = {}
     }
     return store[storeName][id]

--- a/plugins/tap13.js
+++ b/plugins/tap13.js
@@ -1,4 +1,6 @@
-var _ = require('lodash')
+var _each = require('lodash/each')
+var _filter = require('lodash/filter')
+var _map = require('lodash/map')
 
 var Tap13 = require('../lib/report/tap13')
 var countTests = require('../lib/count-tests')
@@ -25,7 +27,7 @@ module.exports = function (log) {
             skipped: result.skipped
           })
 
-          _.each(result.errors, function (erObj) {
+          _each(result.errors, function (erObj) {
             tap13.error(erObj.error)
           })
 
@@ -38,7 +40,7 @@ module.exports = function (log) {
           preludePrinted = true
         }
         runSuite(function (er, result) {
-          _(result.errors).filter(['metadata', metadata]).map('error').each(function (er) {
+          _map(_filter(result.errors, ['metadata', metadata]), 'error').forEach(function (er) {
             tap13.error(er, 'suite: "' + metadata.name + '" in ' +
                             '`' + metadata.file + '`')
           })

--- a/plugins/uncaught-exception.js
+++ b/plugins/uncaught-exception.js
@@ -1,11 +1,11 @@
-var _ = require('lodash')
+var _once = require('lodash/once')
 
 module.exports = function () {
   return {
     name: 'teenytest-uncaught-exception',
     supervisors: {
       userFunction: function (runUserFunction, metadata, cb) {
-        var onceCb = _.once(cb)
+        var onceCb = _once(cb)
         var uncaughtErrorHandler = function uncaughtErrorHandler (er) {
           process.removeListener('uncaughtException', uncaughtErrorHandler)
           onceCb(er)


### PR DESCRIPTION
Whole-lodash requires removed from index, lib/, and plugins/. Not intending to remove from example/ or test/ unless either of those would be within the code-path of the profiler.

This should be good to go for profiling to see if it's worth avoiding the "whole-lodash" tax. There is plenty of room for improvement by switching to the native variants where it makes sense. (Most notably, _assign, _map, _each, and _filter; of course only in the cases not using lodash shorthand) I'm assuming teentytest sets ES5 as a baseline of support so these are all safe.
