### PR TITLE
fix npm script example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We prefer including our script in the `scripts` section of our package.json:
 
 ``` json
 "scripts": {
-  "test": "teenytest **/*.test.js --helper test/support/helper.js"
+  "test": "teenytest test/lib/**/*.js --helper test/helper.js"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We prefer including our script in the `scripts` section of our package.json:
 
 ``` json
 "scripts": {
-  "test": "teenytest test/lib/**/*.js --helper test/helper.js"
+  "test": "teenytest test/lib/**/*.test.js --helper test/helper.js"
 }
 ```
 


### PR DESCRIPTION
with the globbing in place in the old example tests were being run within node_modules or any folder that the glob matched that contained a `*.test.js` file.