### PR TITLE
Print summary at the bottom of a test run

### DIFF
--- a/plugins/tap13/builder.js
+++ b/plugins/tap13/builder.js
@@ -28,8 +28,32 @@ Tap13.prototype.error = function (er, standaloneDescription) {
 }
 
 Tap13.prototype.summarize = function (summary) {
-  this.log('# Test run ' + (summary.failed === 0 ? 'passed!' : 'failed!'))
-  this.log('#   Run:    ' + summary.total)
-  this.log('#   Passed: ' + summary.passed)
-  this.log('#   Failed: ' + summary.failed)
+  var p = this.log
+  p('# Test run ' + (summary.failed === 0 ? 'passed!' : 'failed!'))
+  p('#   Passed: ' + summary.passed)
+  p('#   Failed: ' + summary.failed)
+  p('#   Total:  ' + summary.total)
+
+  if (summary.failures.length > 0) {
+    p('#')
+    p('# Failures:')
+    _.each(summary.failures, function (failure) {
+      p('#')
+      p('#   ' + failure.description)
+      if (failure.setUpFailed) {
+        p('#')
+        p('#     A setup hook (beforeEach or beforeAll) failed so the test never ran')
+      }
+      _.each(failure.errors, function (errorObj) {
+        p('#')
+        if (errorObj.error.stack) {
+          p(_.map(errorObj.error.stack.split('\n'), function (stackLine) {
+            return '#     ' + stackLine
+          }).join('\n'))
+        } else {
+          p('#    Error: ' + errorObj.error)
+        }
+      })
+    })
+  }
 }

--- a/plugins/tap13/builder.js
+++ b/plugins/tap13/builder.js
@@ -26,3 +26,10 @@ Tap13.prototype.error = function (er, standaloneDescription) {
   this.log('  stacktrace:', er.stack)
   this.log('  ...')
 }
+
+Tap13.prototype.summarize = function (summary) {
+  this.log('# Test run ' + (summary.failed === 0 ? 'passed!' : 'failed!'))
+  this.log('#   Run:    ' + summary.total)
+  this.log('#   Passed: ' + summary.passed)
+  this.log('#   Failed: ' + summary.failed)
+}

--- a/plugins/tap13/index.js
+++ b/plugins/tap13/index.js
@@ -2,10 +2,12 @@ var _ = require('lodash')
 
 var Tap13 = require('./builder')
 var countTests = require('./count-tests')
+var Summary = require('./summary')
 
 module.exports = function (log) {
   var tap13 = new Tap13(log)
   var preludePrinted = false
+  var summary = new Summary()
 
   return {
     name: 'teenytest-tap13',
@@ -20,6 +22,7 @@ module.exports = function (log) {
       },
       test: function (runTest, metadata, cb) {
         runTest(function (er, result) {
+          summary.logTest(metadata, result)
           tap13.test(metadata.description, {
             passing: result.passing,
             skipped: result.skipped
@@ -33,7 +36,9 @@ module.exports = function (log) {
         })
       },
       suite: function (runSuite, metadata, cb) {
+        var topLevelSuite = false
         if (!preludePrinted) {
+          topLevelSuite = true
           tap13.prelude(countTests(metadata))
           preludePrinted = true
         }
@@ -42,6 +47,9 @@ module.exports = function (log) {
             tap13.error(er, 'suite: "' + metadata.name + '" in ' +
                             '`' + metadata.file + '`')
           })
+          if (topLevelSuite) {
+            tap13.summarize(summary)
+          }
           cb(er)
         })
       }

--- a/plugins/tap13/summary.js
+++ b/plugins/tap13/summary.js
@@ -16,7 +16,8 @@ Summary.prototype.logTest = function (metadata, result) {
     this.failures.push({
       description: metadata.description,
       errors: result.errors,
-      setUpFailed: result.setupFailed
+      setUpFailed: result.setUpFailed || result.skipped
+      //^ skipped is a misnomer. Right now only ever used if a beforeEach/all fails :-/
     })
   }
 }

--- a/plugins/tap13/summary.js
+++ b/plugins/tap13/summary.js
@@ -17,7 +17,7 @@ Summary.prototype.logTest = function (metadata, result) {
       description: metadata.description,
       errors: result.errors,
       setUpFailed: result.setUpFailed || result.skipped
-      //^ skipped is a misnomer. Right now only ever used if a beforeEach/all fails :-/
+      // ^ skipped is a misnomer. Right now only ever used if a beforeEach/all fails :-/
     })
   }
 }

--- a/plugins/tap13/summary.js
+++ b/plugins/tap13/summary.js
@@ -1,0 +1,22 @@
+function Summary () {
+  this.total = 0
+  this.passed = 0
+  this.failed = 0
+  this.skipped = 0
+  this.failures = [] // {errors, locator}
+}
+module.exports = Summary
+
+Summary.prototype.logTest = function (metadata, result) {
+  this.total++
+  if (result.passing) {
+    this.passed++
+  } else {
+    this.failed++
+    this.failures.push({
+      description: metadata.description,
+      errors: result.errors,
+      setUpFailed: result.setupFailed
+    })
+  }
+}

--- a/safe/async-test.js
+++ b/safe/async-test.js
@@ -25,7 +25,29 @@ module.exports = function (cb) {
       /stacktrace: AssertionError: 98 == 42/,
       '  ...',
       'ok 5 - "firstTest" - test #1 in `safe/fixtures/async-good-test.js`',
-      'ok 6 - "secondTest" - test #2 in `safe/fixtures/async-good-test.js`'
+      'ok 6 - "secondTest" - test #2 in `safe/fixtures/async-good-test.js`',
+      '# Test run failed!',
+      '#   Passed: 2',
+      '#   Failed: 4',
+      '#   Total:  6',
+      '#',
+      '# Failures:',
+      '#',
+      '#   1 - "test1" - test #1 in `safe/fixtures/async-beforeAll-fails-all.js`',
+      '#',
+      '#     A setup hook (beforeEach or beforeAll) failed so the test never ran',
+      '#',
+      '#   2 - "test2" - test #2 in `safe/fixtures/async-beforeAll-fails-all.js`',
+      '#',
+      '#     A setup hook (beforeEach or beforeAll) failed so the test never ran',
+      '#',
+      '#   3 - test #1 in `safe/fixtures/async-error-test.js`',
+      '#',
+      /#     Error: Something bad/,
+      '#',
+      '#   4 - test #1 in `safe/fixtures/async-fail-test.js`',
+      '#',
+      /#     AssertionError: 98 == 42/
     )
     cb(er)
   })

--- a/safe/async-test.js
+++ b/safe/async-test.js
@@ -43,11 +43,11 @@ module.exports = function (cb) {
       '#',
       '#   3 - test #1 in `safe/fixtures/async-error-test.js`',
       '#',
-      /#     Error: Something bad/,
+      /# {5}Error: Something bad/,
       '#',
       '#   4 - test #1 in `safe/fixtures/async-fail-test.js`',
       '#',
-      /#     AssertionError: 98 == 42/
+      /# {5}AssertionError: 98 == 42/
     )
     cb(er)
   })

--- a/safe/basic-test.js
+++ b/safe/basic-test.js
@@ -9,7 +9,11 @@ module.exports = function (cb) {
       '1..3',
       'ok 1 - test #1 in `safe/fixtures/basic-test-passing-function.js`',
       'ok 2 - "bar" - test #1 in `safe/fixtures/basic-test-passing-object.js`',
-      'ok 3 - "baz" - test #2 in `safe/fixtures/basic-test-passing-object.js`'
+      'ok 3 - "baz" - test #2 in `safe/fixtures/basic-test-passing-object.js`',
+      '# Test run passed!',
+      '#   Run:    3',
+      '#   Passed: 3',
+      '#   Failed: 0'
     )
     cb(er)
   })

--- a/safe/basic-test.js
+++ b/safe/basic-test.js
@@ -11,9 +11,9 @@ module.exports = function (cb) {
       'ok 2 - "bar" - test #1 in `safe/fixtures/basic-test-passing-object.js`',
       'ok 3 - "baz" - test #2 in `safe/fixtures/basic-test-passing-object.js`',
       '# Test run passed!',
-      '#   Run:    3',
       '#   Passed: 3',
-      '#   Failed: 0'
+      '#   Failed: 0',
+      '#   Total:  3'
     )
     cb(er)
   })

--- a/safe/error-test.js
+++ b/safe/error-test.js
@@ -1,0 +1,37 @@
+var helper = require('./support/helper')
+var assert = require('core-assert')
+
+module.exports = function (cb) {
+  helper.run('safe/fixtures/fail-function.js', function (er, result, log) {
+    assert.equal(result, false)
+    log.assert(
+      'TAP version 13',
+      '1..2',
+      'not ok 1 - "raw error" - test #1 in `safe/fixtures/fail-function.js`',
+      '  ---',
+      '  message: undefined',
+      '  stacktrace: ',
+      '  ...',
+      'not ok 2 - "error object" - test #2 in `safe/fixtures/fail-function.js`',
+      '  ---',
+      '  message: wrapped',
+      /stacktrace: Error: wrapped/,
+      '  ...',
+      '# Test run failed!',
+      '#   Passed: 0',
+      '#   Failed: 2',
+      '#   Total:  2',
+      '#',
+      '# Failures:',
+      '#',
+      '#   1 - "raw error" - test #1 in `safe/fixtures/fail-function.js`',
+      '#',
+      '#    Error: raw',
+      '#',
+      '#   2 - "error object" - test #2 in `safe/fixtures/fail-function.js`',
+      '#',
+      /# {5}Error: wrapped/
+    )
+    cb(er)
+  })
+}

--- a/safe/fixtures/fail-function.js
+++ b/safe/fixtures/fail-function.js
@@ -1,1 +1,8 @@
-module.exports = function () { throw new Error('poop') }
+module.exports = {
+  'raw error': function () {
+    throw 'raw' // eslint-disable-line
+  },
+  'error object': function () {
+    throw new Error('wrapped')
+  }
+}

--- a/safe/nested-deep-and-sparse-test.js
+++ b/safe/nested-deep-and-sparse-test.js
@@ -11,7 +11,18 @@ module.exports = function (cb) {
       'not ok 2 - "a b c d doh" - test #2 in `safe/fixtures/nested-sparse-test.js`',
       '  ---',
       '  message: Doh',
-      /stacktrace: Error: Doh/
+      /stacktrace: Error: Doh/,
+      '  ...',
+      '# Test run failed!',
+      '#   Passed: 1',
+      '#   Failed: 1',
+      '#   Total:  2',
+      '#',
+      '# Failures:',
+      '#',
+      '#   2 - "a b c d doh" - test #2 in `safe/fixtures/nested-sparse-test.js`',
+      '#',
+      /# {5}Error: Doh/
     )
     cb(er)
   })


### PR DESCRIPTION
Now that I have a few teenytest suites with hundreds of tests, digging through the output to find a single failure in a test run is too much of a pain. At @schoonology's advice, I decided to just tack on a bunch of one-line comments at the end of the TAP input to summarize the test run (totals as well as reiterating failures.

It's a bit of a shame that the error-printing logic is separate for the failure summaries, but that was hard to avoid in this case and I didn't want unwinding that to become a showstopper to shipping this.