### PR TITLE
feature: Support array of globs as testLocator

### DIFF
--- a/lib/prepare/modules/load.js
+++ b/lib/prepare/modules/load.js
@@ -6,7 +6,18 @@ function noOpHook () {}
 var HOOK_NAMES = ['beforeEach', 'beforeAll', 'afterEach', 'afterAll']
 
 module.exports = function (globPattern, cwd) {
-  return _.map(glob.sync(globPattern), function (file) {
+  var fileList
+  if (_.isArray(globPattern)) {
+    fileList = _.chain(globPattern)
+    .map(function(pattern) {
+      return glob.sync(pattern)
+    })
+    .flatten()
+    .value()
+  } else {
+    fileList = glob.sync(globPattern)
+  }
+  return _.map(fileList, function (file) {
     var testPath = path.resolve(cwd, file)
     var testModule = require(testPath)
 


### PR DESCRIPTION
It's sometimes very complicated, if not impossible to construct a glob string that matches all test files in some locations. This change makes it simpler by supporting arrays of globs. 
E.g. in package.json the "testLocator" property can now look like this:
```json
"testLocator": [
  "./@(models|routes|middleware)/**/*.test.js",
  "./config.test.js",
  "./node_modules/my-custom-module/**/*.test.js"
]
```
A single string is still supported, of course.