### PR TITLE
Port the test:example tests to bats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bats": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.1.0.tgz",
+      "integrity": "sha512-1pA29OhDByrUtAXX+nmqZxgRgx2y8PvuZzbLJVjd2dpEDVDvz0MjcBMdmIPNq5lC+tG53G+RbeRsbIlv3vw7tg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "resolve": "^1.10.0"
   },
   "devDependencies": {
+    "bats": "^1.1.0",
     "core-assert": "^1.0.0",
     "standard": "^12.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "test": "npm run test:unit && npm run test:safe && npm run test:example && npm run style",
     "test:unit": "cd unit && npm install && npm test",
     "test:safe": "./safe/support/runner.js",
-    "test:example": "npm run test:example:multiglob && npm run test:example:failure",
-    "test:example:multiglob": "cd example/simple-node && npm test -- test/lib/multi-word-names.js:10 | grep \"1\\.\\.1\"",
-    "test:example:failure": "cd example/simple-node && npm test | grep 'not ok 9 - \"blueIsRed\" - test #1 in `test/lib/single-function.js`' && echo 'Good! Above error is expected'"
+    "test:example": "bats --tap safe"
   },
   "keywords": [
     "teeny",

--- a/safe/example.bats
+++ b/safe/example.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+@test "accepts line number is path suffix" {
+  cd "$BATS_TEST_DIRNAME/../example/simple-node"
+
+  run npm test -- test/lib/multi-word-names.js:10
+
+  [[ $status -eq 0 ]]
+  [[ "$output" =~ 1..1 ]]
+  [[ "$output" =~ 'test #1 in `test/lib/multi-word-names.js`' ]]
+}
+
+@test "failed tests report not-ok" {
+  cd "$BATS_TEST_DIRNAME/../example/simple-node"
+
+  run npm test
+
+  [[ $status -eq 1 ]]
+  [[ "$output" =~ 'not ok 9 - "blueIsRed" - test #1 in `test/lib/single-function.js`' ]]
+}


### PR DESCRIPTION
The smoke tests of the example project are a bit confusing as they're
inlined in npm-scripts; especially as one test asserts an expected
failure (which causes "not ok" to be printed to output)

This PR adds bats (unit test framework for bash) as a devDep and
implements the two example tests in bats.

I suspect bats would make a superior tool for testing the teenytest CLI
(and/or for SAFE tests). Doing so would allow a clean cognitive break
between "JS of teenytest" and "JS of the test". Bats is also
specifically built for testing command line utilities, so asserting on
output and exit status after running commands is intuitive. However,
this PR does not make any assumptions about the future use of bats
within teenytest's test suite. So there is no directory of bats tests,
nor does this test pull in any of the common bats assertion helpers or
create a test_helper.bash. Those things will be desired if a larger bats
test suite is built. For now, this PR limits bats use to _only_ the two
example tests that were in package.json; and the test file is placed in
the safe directory. (But as it is a .bats file, isn't run by the safe
suite; instead being run via `bats safe` or the corresponding npm run
test:example script.)

/cc @agent-0028 @cpruitt 