### PR TITLE
Add support for loading ESM tests

### DIFF
--- a/example/simple-node/test/lib/dog-test.mjs
+++ b/example/simple-node/test/lib/dog-test.mjs
@@ -1,0 +1,24 @@
+import assert from 'core-assert';
+import Dog from '../../lib/dog.js';
+
+export function beforeEach() {
+  this.subject = new Dog('Sam')
+};
+
+export const bark = {
+  once() {
+    assert.deepEqual(this.subject.bark(1), ['Woof #0'])
+  },
+  twice() {
+    assert.deepEqual(this.subject.bark(2), ['Woof #0', 'Woof #1'])
+  }
+};
+
+export const tag = {
+  frontSaysName() {
+    assert.equal(this.subject.tag('front'), 'Hi, I am Sam')
+  },
+  backSaysAddress() {
+    assert.equal(this.subject.tag('back'), 'And here is my address')
+  }
+};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,16 @@ var run = require('./lib/run')
 module.exports = function (testLocator, userOptions, cb) {
   if (arguments.length < 3) { cb = userOptions; userOptions = {} }
   var config = configure(testLocator, userOptions)
-  run(plan(prepare(config)), config, cb)
+  prepare(config)
+    .then(function (prepared) {
+      setImmediate(function () {
+        run(plan(prepared), config, cb)
+      })
+    }, function (er) {
+      setImmediate(function () {
+        cb(er)
+      })
+    })
 }
 
 module.exports.plugins = require('./lib/plugins/store')

--- a/lib/configure/defaults.js
+++ b/lib/configure/defaults.js
@@ -2,7 +2,7 @@ module.exports = function () {
   return {
     cwd: process.cwd(),
     output: console.log,
-    testLocator: 'test/lib/**/*.js',
+    testLocator: 'test/lib/**/*.{js,mjs}',
     name: [],
     helperPath: 'test/helper.js',
     asyncTimeout: 5000,

--- a/lib/prepare/index.js
+++ b/lib/prepare/index.js
@@ -1,9 +1,10 @@
-var modules = require('./modules')
-var helper = require('./helper')
+var loadModules = require('./modules')
+var loadHelper = require('./helper')
 
-module.exports = function (config) {
-  return {
-    helper: helper(config.helperPath, config.cwd),
-    modules: modules(config.criteria, config.cwd)
-  }
+module.exports = async function (config) {
+  const [helper, modules] = await Promise.all([
+    loadHelper(config.helperPath, config.cwd),
+    loadModules(config.criteria, config.cwd)
+  ]);
+  return { helper, modules }
 }

--- a/lib/prepare/modules/index.js
+++ b/lib/prepare/modules/index.js
@@ -3,12 +3,13 @@ var filter = require('./filter')
 var compact = require('./compact')
 var _ = require('lodash')
 
-module.exports = function (criteria, cwd) {
-  return compact(_.compact(_.flatten(_.map(criteria.testFiles, function (fileCriteria) {
+module.exports = async function (criteria, cwd) {
+  const loadedFiles = await Promise.all(_.map(criteria.testFiles, async function (fileCriteria) {
     return filter(
-      load(fileCriteria.file, cwd),
+      await load(fileCriteria.file, cwd),
       fileCriteria,
       cwd
     )
-  }))))
+  }));
+  return compact(_.compact(_.flatten(loadedFiles)))
 }

--- a/lib/prepare/modules/load.js
+++ b/lib/prepare/modules/load.js
@@ -5,13 +5,19 @@ var _ = require('lodash')
 function noOpHook () {}
 var HOOK_NAMES = ['beforeEach', 'beforeAll', 'afterEach', 'afterAll']
 
-module.exports = function (globPattern, cwd) {
-  return _.map(glob.sync(globPattern), function (file) {
+module.exports = async function (globPattern, cwd) {
+  return Promise.all(_.map(glob.sync(globPattern), async function (file) {
     var testPath = path.resolve(cwd, file)
-    var testModule = require(testPath)
+    var testModule;
+    try {
+      testModule = require(testPath)
+    } catch (e) {
+      if (e.code !== 'ERR_REQUIRE_ESM') throw e;
+      testModule = await import(testPath)
+    }
 
     return buildExampleGroup(testPath, testModule, file, [{ name: 'global' }])
-  })
+  }))
 }
 
 function buildExampleGroup (name, groupDeclaration, file, ancestors) {


### PR DESCRIPTION
This is an early exploration of how module support could be added. Known issues:

- [ ] Uses async/await so 0.10 support wouldn't be maintained.
- [ ] Uses `import()` syntax so that would either have to be isolated into its own lazy-loaded file or would bump the required version even further. Loading a file with `import()` syntax on `ERR_REQUIRE_ESM` should be safe though.
- [ ] Actual tests.

Fixes https://github.com/testdouble/teenytest/issues/52

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.4)_