### PR TITLE
support Node v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "8"
   - "10"
   - "12"
   - "13"

--- a/lib/prepare/modules/import.js
+++ b/lib/prepare/modules/import.js
@@ -1,0 +1,4 @@
+
+module.exports = function importModule (path) {
+  return import(path)
+}

--- a/lib/prepare/modules/load.js
+++ b/lib/prepare/modules/load.js
@@ -5,6 +5,10 @@ var _ = require('lodash')
 function noOpHook () {}
 var HOOK_NAMES = ['beforeEach', 'beforeAll', 'afterEach', 'afterAll']
 
+const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1), 10)
+
+const importModule = nodeMajorVersion >= 10 ? require('./import') : undefined
+
 module.exports = async function (globPattern, cwd) {
   return Promise.all(_.map(glob.sync(globPattern), async function (file) {
     var testPath = path.resolve(cwd, file)
@@ -12,9 +16,9 @@ module.exports = async function (globPattern, cwd) {
     try {
       testModule = require(testPath)
     } catch (e) {
-      if (e.code !== 'ERR_REQUIRE_ESM') throw e
+      if (e.code !== 'ERR_REQUIRE_ESM' || !importModule) throw e
       try {
-        testModule = await import(testPath)
+        testModule = await importModule(testPath)
       } catch (err) {
         if (err.message !== 'Not supported') throw err
         const message = `You are trying to load test files that are ES modules (${testPath}), but ESM is not supported in this version of Node.js`


### PR DESCRIPTION
Due to the addition of code with `import(...)`, Node v8 stopped being supported as Node v8 considers `import` to be a "syntax" error, so the runtime sniffing didn't work.

1. I `require` a file with `import` only from Node v10 and above.
2. I added Node v8 to the Travis matrix.
