### PR TITLE
show loading errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ module.exports = function (testLocator, userOptions, cb) {
         run(plan(prepared), config, cb)
       })
     }, function (er) {
+      var log = userOptions.output || console.log
+      log(er.stack || String(er))
       setImmediate(function () {
         cb(er)
       })

--- a/safe/fixtures/syntax-error-test.js
+++ b/safe/fixtures/syntax-error-test.js
@@ -1,0 +1,1 @@
+throw new Error('this is a loading error')

--- a/safe/test-script-error-test.js
+++ b/safe/test-script-error-test.js
@@ -4,8 +4,8 @@ var assert = require('assert')
 module.exports = function (cb) {
   helper.run('safe/fixtures/syntax-error-test.js', function (er, result, log) {
     assert.strictEqual(result, undefined)
-    assert.match(log.read()[0], /Error: this is a loading error/)
-    assert.match(log.read()[0], /syntax-error-test\.js/)
+    assert(log.read()[0].match(/Error: this is a loading error/))
+    assert(log.read()[0].match(/syntax-error-test\.js/))
     cb()
   })
 }

--- a/safe/test-script-error-test.js
+++ b/safe/test-script-error-test.js
@@ -1,0 +1,11 @@
+var helper = require('./support/helper')
+var assert = require('assert')
+
+module.exports = function (cb) {
+  helper.run('safe/fixtures/syntax-error-test.js', function (er, result, log) {
+    assert.strictEqual(result, undefined)
+    assert.match(log.read()[0], /Error: this is a loading error/)
+    assert.match(log.read()[0], /syntax-error-test\.js/)
+    cb()
+  })
+}


### PR DESCRIPTION
If a test module fails to load (syntax error or any other exception), teenytest is currently
silent about it. Not sure whether this is a regression due to the ESM change, or was always like 
this, but this PR fixes it (with a test).﻿
