### PR TITLE
ci: use bash shell when spawning tests on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
       "devDependencies": {
         "bats": "^1.1.0",
         "core-assert": "^1.0.0",
-        "standard": "^14.3.3"
+        "standard": "^14.3.3",
+        "which": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -334,6 +335,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/debug": {
@@ -2557,15 +2570,18 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/word-wrap": {
@@ -2850,6 +2866,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -4586,9 +4611,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "devDependencies": {
     "bats": "^1.1.0",
     "core-assert": "^1.0.0",
-    "standard": "^14.3.3"
+    "standard": "^14.3.3",
+    "which": "^3.0.0"
   },
   "standard": {
     "ignore": [

--- a/safe/plugin-configuration-test.js
+++ b/safe/plugin-configuration-test.js
@@ -2,7 +2,7 @@ var async = require('async')
 var spawn = require('child_process').spawn
 var path = require('path')
 var assert = require('core-assert')
-
+var which = require('which')
 var helper = require('./support/helper')
 
 module.exports = function (cb) {
@@ -47,9 +47,16 @@ function runWithPlugins (name) {
 }
 
 function run (projectDir, cb) {
-  var test = spawn('npm', ['test'], {
+  var options = {
     cwd: path.resolve(process.cwd(), 'safe/fixtures/projects/' + projectDir)
-  })
+  }
+  if (process.platform === 'win32') {
+    const bashPath = which.sync('bash', { nothrow: true })
+    if (bashPath) {
+      options.shell = bashPath
+    }
+  }
+  var test = spawn('npm', ['test'], options)
 
   var log = ''
   test.stdout.on('data', function (text) {


### PR DESCRIPTION
Some spawned tests expect to be running in a UNIX environment (shebang checking for example).  When spawning tests on Windows, the shell will now be bash.  It is expected that maintainers will have bash available (it may be git bash).

Spawned processes will now find the command to run instead of getting `ENOENT` errors.  The `shell: true` option on spawn does not resolve the need for shebang support.