### PR TITLE
fix: use file URL for esm import and remove node version check

### DIFF
--- a/lib/prepare/modules/load.js
+++ b/lib/prepare/modules/load.js
@@ -5,10 +5,6 @@ var _ = require('lodash')
 function noOpHook () {}
 var HOOK_NAMES = ['beforeEach', 'beforeAll', 'afterEach', 'afterAll']
 
-const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1), 10)
-
-const importModule = nodeMajorVersion >= 10 ? require('./import') : undefined
-
 module.exports = async function (globPattern, cwd) {
   return Promise.all(_.map(glob.sync(globPattern), async function (file) {
     var testPath = path.resolve(cwd, file)
@@ -16,15 +12,8 @@ module.exports = async function (globPattern, cwd) {
     try {
       testModule = require(testPath)
     } catch (e) {
-      if (e.code !== 'ERR_REQUIRE_ESM' || !importModule) throw e
-      try {
-        testModule = await importModule(testPath)
-      } catch (err) {
-        if (err.message !== 'Not supported') throw err
-        const message = `You are trying to load test files that are ES modules (${testPath}), but ESM is not supported in this version of Node.js`
-        console.error(message)
-        throw new Error(message)
-      }
+      if (e.code !== 'ERR_REQUIRE_ESM') throw e
+      testModule = await import(testPath)
     }
 
     return buildExampleGroup(testPath, testModule, file, [{ name: 'global' }])

--- a/lib/prepare/modules/load.js
+++ b/lib/prepare/modules/load.js
@@ -13,7 +13,7 @@ module.exports = async function (globPattern, cwd) {
       testModule = require(testPath)
     } catch (e) {
       if (e.code !== 'ERR_REQUIRE_ESM') throw e
-      testModule = await import(testPath)
+      testModule = await import('file://' + testPath)
     }
 
     return buildExampleGroup(testPath, testModule, file, [{ name: 'global' }])


### PR DESCRIPTION
The first commit does a little cleanup under the assumption import is always available now.

1. maint: remove check for node esm support
  Currently supported node versions no longer need the check for esm import support.
2. fix: use file URL for esm import
  The fully qualified path needs to be a URL type to work on Windows.

The fix addresses a problem found running the quibble CI for PR [89](https://github.com/testdouble/quibble/pull/89) on Windows.

The problem can be recreated on Windows by adding this test to `package.json`:
`"test:safe:esm": "cd example/esm-node && npm test -- test/lib/dog-test.mjs:10",`
The recreate was not added to this patch series in case a different implementation is preferred.

Tested on Windows on both cmd and bash 'shells'.