### PR TITLE
ci/dev: Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/example/esm-node/package.json
+++ b/example/esm-node/package.json
@@ -7,6 +7,6 @@
     "test": "test"
   },
   "scripts": {
-    "test": "teenytest"
+    "test": "node ../../bin/teenytest"
   }
 }

--- a/example/simple-node/package.json
+++ b/example/simple-node/package.json
@@ -7,6 +7,6 @@
     "test": "test"
   },
   "scripts": {
-    "test": "teenytest"
+    "test": "node ../../bin/teenytest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "scripts": {
     "style": "standard --fix",
-    "test": "npm run test:unit && npm run test:safe && npm run test:safe:bats && npm run style",
+    "test": "npm run test:unit && npm run test:safe && npm run test:safe:bats && npm run test:safe:esm && npm run style",
     "test:unit": "cd unit && npm install && npm test",
-    "test:safe": "./safe/support/runner.js",
-    "test:safe:bats": "bats --tap --recursive safe"
+    "test:safe": "node ./safe/support/runner.js",
+    "test:safe:esm": "cd example/esm-node && npm test -- test/lib/dog-test.mjs:10",
+    "test:safe:bats": "bash -c 'bats --tap --recursive safe'"
   },
   "keywords": [
     "teeny",

--- a/safe/fixtures/projects/customize-cli/config/teenyfile.js
+++ b/safe/fixtures/projects/customize-cli/config/teenyfile.js
@@ -1,4 +1,4 @@
-const otherPrinterPlugin = require('../plugins/other-printer')
+const otherPrinterPlugin = require('../../vanilla/plugins/other-printer')
 
 module.exports = function (teenytest, cb) {
   teenytest.plugins.register(otherPrinterPlugin)

--- a/safe/fixtures/projects/customize-cli/package.json
+++ b/safe/fixtures/projects/customize-cli/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "../../../../bin/teenytest --plugin ./plugins/printer --configurator \"config/teenyfile\" \"test/**/*.js\""
+    "test": "../../../../bin/teenytest --plugin ../vanilla/plugins/printer --configurator \"config/teenyfile\" \"test/**/*.js\""
   },
   "author": ""
 }

--- a/safe/fixtures/projects/customize-configurator/config/teenyfile.js
+++ b/safe/fixtures/projects/customize-configurator/config/teenyfile.js
@@ -1,5 +1,5 @@
-const printerPlugin = require('../plugins/printer')
-const otherPrinterPlugin = require('../plugins/other-printer')
+const printerPlugin = require('../../vanilla/plugins/printer')
+const otherPrinterPlugin = require('../../vanilla/plugins/other-printer')
 
 const assert = require('core-assert')
 

--- a/safe/fixtures/projects/customize-plugins/package.json
+++ b/safe/fixtures/projects/customize-plugins/package.json
@@ -4,13 +4,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "../../../../bin/teenytest \"test/**/*.js\""
+    "test": "node ../../../../bin/teenytest test/**/*.js"
   },
   "author": "",
   "teenytest": {
     "plugins": [
-      "plugins/printer",
-      "./plugins/other-printer"
+      "../vanilla/plugins/printer",
+      "../vanilla/plugins/other-printer"
     ]
   }
 }

--- a/safe/fixtures/projects/customize-plugins/test
+++ b/safe/fixtures/projects/customize-plugins/test
@@ -1,1 +1,0 @@
-../vanilla/test

--- a/safe/fixtures/projects/customize-plugins/test/simple-test.js
+++ b/safe/fixtures/projects/customize-plugins/test/simple-test.js
@@ -1,0 +1,10 @@
+const assert = require('core-assert')
+
+module.exports = {
+  add: function () {
+    assert.equal(5, 3 + 2)
+  },
+  subtract: function () {
+    assert.equal(5, 11 - 6)
+  }
+}


### PR DESCRIPTION
This patch series provides support for running development and the CI on Windows.  It includes changes listed in issue #26 (and includes some that were missed).

1.    ci: force linends to lf on all platforms
    Windows has issues running bash scripts with crlf.

1.    maint: replace link with actual file
    git may not create links for the test file.  Other test files are not links so maybe this does not need to be one either.

1.    maint: change links to relative paths
    git does not always create links so using relative paths expands on WIndows compatability.

1.    ci: do not rely on shebang support
    Running on Windows needs the command to be specified in `package.json`.

1.    ci: windows support and windows specific test
    Remove some shebang assumptions.
    Added test:safe:esm which runs some tests for Windows in the cmd shell. test:safe:bats tests run under bash so they do not test WIndows pathname  issues.  This is the test mentioned in pr #75.

Tested on Windows cmd and wsl. 

No offence if some of the patches are not accepted (or none) or need changes.  This provides a record for the future.  If the changes are accepted, there may be some link cleanup to be done.
