### PR TITLE
ci: do not expect bash on Windows

### DIFF
--- a/safe/fixtures/projects/customize-cli/package.json
+++ b/safe/fixtures/projects/customize-cli/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "../../../../bin/teenytest --plugin ../vanilla/plugins/printer --configurator \"config/teenyfile\" \"test/**/*.js\""
+    "test": "node ../../../../bin/teenytest --plugin ../vanilla/plugins/printer --configurator \"config/teenyfile\" \"test/**/*.js\""
   },
   "author": ""
 }

--- a/safe/fixtures/projects/customize-configurator/package.json
+++ b/safe/fixtures/projects/customize-configurator/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "../../../../bin/teenytest \"test/**/*.js\""
+    "test": "node ../../../../bin/teenytest \"test/**/*.js\""
   },
   "author": "",
   "teenytest": {

--- a/safe/fixtures/projects/vanilla/package.json
+++ b/safe/fixtures/projects/vanilla/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "../../../../bin/teenytest \"test/**/*.js\""
+    "test": "node ../../../../bin/teenytest \"test/**/*.js\""
   },
   "author": ""
 }

--- a/safe/plugin-configuration-test.js
+++ b/safe/plugin-configuration-test.js
@@ -2,7 +2,6 @@ const async = require('async')
 const spawn = require('child_process').spawn
 const path = require('path')
 const assert = require('core-assert')
-const which = require('which')
 const helper = require('./support/helper')
 
 module.exports = function (cb) {
@@ -51,10 +50,7 @@ function run (projectDir, cb) {
     cwd: path.resolve(process.cwd(), 'safe/fixtures/projects/' + projectDir)
   }
   if (process.platform === 'win32') {
-    const bashPath = which.sync('bash', { nothrow: true })
-    if (bashPath) {
-      options.shell = bashPath
-    }
+    options.shell = true
   }
   const test = spawn('npm', ['test'], options)
 


### PR DESCRIPTION
A full bash environment is only available with wsl2 so do not rely on it.  Run spawned processes in cmd shell on Windows.  `package.json` used for these tests now specify node should be run instead of relying on shebang support.

wsl2 is not available on the `windows-latest` build.  Only git bash is available and it is still a `win32` platform.  As a result, in the spawned processes, npm still tries to run a cmd shell instead of a bash shell for running scripts.