### PR TITLE
ci: escape wildcards to avoid shell expansion

### DIFF
--- a/safe/fixtures/projects/customize-plugins/package.json
+++ b/safe/fixtures/projects/customize-plugins/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ../../../../bin/teenytest test/**/*.js"
+    "test": "node ../../../../bin/teenytest \"test/**/*.js\""
   },
   "author": "",
   "teenytest": {

--- a/unit/package.json
+++ b/unit/package.json
@@ -4,7 +4,7 @@
   "description": "This is the unit test suite for teenytest",
   "main": "index.js",
   "scripts": {
-    "test": "teenytest test/**/*.js --helper unit-helper.js"
+    "test": "teenytest \"test/**/*.js\" --helper unit-helper.js"
   },
   "devDependencies": {
     "core-assert": "^0.2.1",


### PR DESCRIPTION
Some quotings were incorrectly dropped adding Windows support.  This resulted in globing of the input list instead of it being handled inside teenytest.  It seems `"` is preferred over `'` for Windows and was used in other scripts